### PR TITLE
Revert "Security Fix for Remote Code Execution - huntr.dev"

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -84,7 +84,7 @@ function * initFeature(context, heroku, callback) {
     } else if (!(_hasExecBuildpack(buildpacks, buildpackUrls))) {
       yield _enableFeature(context, heroku)
       cli.log(`Adding the Heroku Exec buildpack to ${context.app}`)
-      child.execFileSync(`heroku`, [`buildpacks:add`, `-i`, `1`, `heroku/exec`, `-a`, `${context.app}`])
+      child.execSync(`heroku buildpacks:add -i 1 heroku/exec -a ${context.app}`)
       cli.log('')
       cli.log('Run the following commands to redeploy your app, then Heroku Exec will be ready to use:')
       cli.log(cli.color.magenta('  git commit -m "Heroku Exec initialization" --allow-empty'))

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -105,8 +105,7 @@ function ssh(context, addonHost, dynoUser, privateKey, proxyKey) {
                 }
 
                 try {
-                  sshCommand = sshCommand.split(' ')
-                  child.execFileSync(sshCommand[0],sshCommand.slice(1), { stdio: ['inherit', 'inherit', 'ignore' ] }
+                  child.execSync(sshCommand, { stdio: ['inherit', 'inherit', 'ignore' ] }
                   )
                 } catch (e) {
                   if (e.stderr) cli.hush(e.stderr)


### PR DESCRIPTION
Reverts heroku/heroku-exec-util#20

Splitting on `' '` may break for any arguments that have spaces but are otherwise properly quoted with double or single quotes.