### PR TITLE
Do not block ps:exec when stack is container

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -78,6 +78,8 @@ function * initFeature(context, heroku, callback) {
     if (data.app['space']['shield'] === true) {
       cli.error(`This feature is restricted for Shield Private Spaces`)
       cli.exit(1);
+    } else if (data.app['build_stack']['name'] === 'container') {
+      cli.warn(`${context.app} is using the container stack which is not officially supported.`);
     } else if (buildpacks.length === 0) {
       cli.error(`${context.app} has no Buildpack URL set. You must deploy your application first!`)
       cli.exit(1);


### PR DESCRIPTION
Hello Herokai friends!

I ran into a client side case where, when using Heroku Private Spaces with Docker containers, we are unable to use `ps:exec` without adding the `heroku/exec` buildpack.

```
𝝙 heroku stack:set container -a $APP
𝝙 heroku ps:exec
▸   $APP has no Buildpack URL set. You must deploy your
▸   application first!

𝝙 heroku buildpacks:add heroku/exec -a $APP
buildpack added. Next release on $APP will use heroku/exec.
Run git push heroku main to create a new release using this buildpack.

𝝙 heroku ps:exec -a $APP
Establishing credentials... done
[... further proof of success]
```

I know it's a use case is [not officially supported](https://devcenter.heroku.com/articles/exec#using-with-docker) but I suspect blocking the connection is an oversight and not intentional.