### PR TITLE
Got version 11.8.6 throws an error with auth option.

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -17,7 +17,8 @@ function * checkStatus(context, heroku, configVars) {
   var execUrl = _execUrl(context, configVars)
 
   return cli.got(`https://${execUrl.host}`, {
-    auth: execUrl.auth,
+    username: execUrl.username,
+    password: execUrl.password,
     path: _execApiPath(configVars),
     headers: _execHeaders(),
     method: 'GET'
@@ -164,7 +165,8 @@ function updateClientKey(context, heroku, configVars, callback) {
     var dyno = _dyno(context)
 
     return cli.got(`https://${execUrl.host}`, {
-      auth: execUrl.auth,
+      username: execUrl.username,
+      password: execUrl.password,
       path: `${_execApiPath(configVars)}/${dyno}`,
       method: 'PUT',
       headers: {..._execHeaders(), 'content-type': 'application/json'},
@@ -211,9 +213,10 @@ function _execUrl(context, configVars) {
     } else {
       urlString = process.env.HEROKU_EXEC_URL
     }
-    var execUrl = url.parse(urlString)
-    execUrl.auth = `${context.app}:${process.env.HEROKU_API_KEY || context.auth.password}`
-    return execUrl
+    var execUrl = url.parse(urlString);
+    execUrl.username = context.app;
+    execUrl.password = process.env.HEROKU_API_KEY || context.auth.password;
+    return execUrl;
   }
 }
 


### PR DESCRIPTION
`yarn.lock` in this package specifies got version 11.8.6, which throws an error when given the `auth` option [here](https://github.com/sindresorhus/got/blob/v11.8.6/source/core/index.ts#L1584-L1586).

The base `heroku-cli` has multiple versions of `got` so I think this might be a module resolution issue.

Full explanation:
As recommended in the docs I'm using the arch package. [ref](https://devcenter.heroku.com/articles/heroku-cli#install-for-arch-linux).

This package removes the pin on node, and reinstalls the dependencies, which removes alternate versions of the got dependency. [ref](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=heroku-cli#n34)

on my machine.
```
$ cat yarn.lock | grep '/got/' | grep resolved
  resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
```

This version of got throws an error if you try and pass `auth` as an option to it, and triggers an error in `ps:exec` in the `updateClientKey` function [here](https://github.com/heroku/heroku-exec-util/blob/main/lib/exec.js#L154). This calls `got` and throws a `TypeError` [here](https://github.com/sindresorhus/got/blob/v11.8.6/source/core/index.ts#L1584-L1586).

Solutions are either re-introduce the node pinning in the aur package, or update `heroku-cli-exec` to use username/password. Let me see about making a PR for that.

internal support ticket: https://help.heroku.com/1417095