### PR TITLE
ci: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  open-pull-requests-limit: 5
+  schedule:
+      interval: "weekly"
+      time: "12:00"
+      day: "sunday"
+      timezone: "America/Los_Angeles"
+- package-ecosystem: "npm"
+  directory: "/"
+  open-pull-requests-limit: 5
+  schedule:
+      interval: "weekly"
+      time: "12:00"
+      day: "sunday"
+      timezone: "America/Los_Angeles"
+  groups:
+    dev-deps:
+      dependency-type: "development"
+    patch-dependencies:
+      update-types:
+        - "patch"
+  ignore:
+    - dependency-name: "@oclif/core"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "typescript"
+      update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
Adds Dependabot configuration to automate dependency updates and resolve the GitHub security alert for missing dependency management.

## Changes
- Added `.github/dependabot.yml` with configuration for:
  - GitHub Actions updates (weekly on Sundays)
  - npm package updates (weekly on Sundays)
  - Grouped development dependencies and patch updates
  - Ignored major version updates for `@oclif/core` and `typescript`

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] CI/CD change (changes to build, test, or deployment processes)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- [x] Configuration file syntax validated
- [x] Dependabot will automatically test by creating initial PRs after merge

## Additional Context
This addresses the GitHub security alert about missing automated dependency management by configuring Dependabot to:
- Keep dependencies up to date automatically
- Limit open PRs to 5 to avoid spam
- Schedule updates for off-peak hours (Sundays at noon PT)
- Strategically ignore major version updates for core dependencies to prevent breaking changes